### PR TITLE
bugfix: internal help function can not be part of deployed version

### DIFF
--- a/deployment/BiofilmQ.prj
+++ b/deployment/BiofilmQ.prj
@@ -361,29 +361,30 @@ The easy-to-use analysis features enable you to generate high-quality data visua
       <file>${PROJECT_ROOT}\..\includes\tools\zSlicer\includes\sort_nat.m</file>
       <file>${PROJECT_ROOT}\..\includes\tools\zSlicer\zSlicer.m</file>
       <file>${PROJECT_ROOT}\..\includes\tools\zSlicer\zSlicer_time.m</file>
-      <file>D:\drescherlab\biofilmq\includes\additional modules</file>
-      <file>D:\drescherlab\biofilmq\includes\additional modules visualization</file>
-      <file>D:\drescherlab\biofilmq\includes\biofilm analysis</file>
-      <file>D:\drescherlab\biofilmq\includes\deconvolution</file>
-      <file>D:\drescherlab\biofilmq\includes\export</file>
-      <file>D:\drescherlab\biofilmq\includes\file handling</file>
-      <file>D:\drescherlab\biofilmq\includes\functionality</file>
-      <file>D:\drescherlab\biofilmq\includes\help</file>
-      <file>D:\drescherlab\biofilmq\includes\image processing</file>
-      <file>D:\drescherlab\biofilmq\includes\image registration</file>
-      <file>D:\drescherlab\biofilmq\includes\layout</file>
-      <file>D:\drescherlab\biofilmq\includes\object processing</file>
-      <file>D:\drescherlab\biofilmq\includes\performance</file>
-      <file>D:\drescherlab\biofilmq\includes\temp</file>
-      <file>D:\drescherlab\biofilmq\includes\tools</file>
+      <file>${PROJECT_ROOT}\..\includes\additional modules</file>
+      <file>${PROJECT_ROOT}\..\includes\additional modules visualization</file>
+      <file>${PROJECT_ROOT}\..\includes\biofilm analysis</file>
+      <file>${PROJECT_ROOT}\..\includes\deconvolution</file>
+      <file>${PROJECT_ROOT}\..\includes\export</file>
+      <file>${PROJECT_ROOT}\..\includes\file handling</file>
+      <file>${PROJECT_ROOT}\..\includes\functionality</file>
+      <file>${PROJECT_ROOT}\..\includes\help</file>
+      <file>${PROJECT_ROOT}\..\includes\image processing</file>
+      <file>${PROJECT_ROOT}\..\includes\image registration</file>
+      <file>${PROJECT_ROOT}\..\includes\layout</file>
+      <file>${PROJECT_ROOT}\..\includes\object processing</file>
+      <file>${PROJECT_ROOT}\..\includes\performance</file>
+      <file>${PROJECT_ROOT}\..\includes\temp</file>
+      <file>${PROJECT_ROOT}\..\includes\tools</file>
+      <file>${PROJECT_ROOT}\..\includes\matlab_funs</file>
     </fileset.resources>
     <fileset.package />
     <fileset.depfun>
-      <file>D:\drescherlab\BiofilmQ\BiofilmQ.fig</file>
-      <file>D:\drescherlab\BiofilmQ\BiofilmQ.m</file>
-      <file>D:\drescherlab\BiofilmQ\directory.mat</file>
-      <file>D:\drescherlab\BiofilmQ\includes\about.m</file>
-      <file>D:\drescherlab\BiofilmQ\includes\biofilmQ_version.txt</file>
+      <file>${PROJECT_ROOT}\..\BiofilmQ.fig</file>
+      <file>${PROJECT_ROOT}\..\BiofilmQ.m</file>
+      <file>${PROJECT_ROOT}\..\directory.mat</file>
+      <file>${PROJECT_ROOT}\..\includes\about.m</file>
+      <file>${PROJECT_ROOT}\..\includes\biofilmQ_version.txt</file>
     </fileset.depfun>
     <build-deliverables>
       <file location="${PROJECT_ROOT}\files-for-deployment\BiofilmQ\testing" name="splash.png" optional="false">D:\drescherlab\BiofilmQ\deployment\files-for-deployment\BiofilmQ\testing\splash.png</file>

--- a/includes/matlab_funs/help.m
+++ b/includes/matlab_funs/help.m
@@ -1,0 +1,9 @@
+% overwrite MATLAB help function since can not be part of a redistribution
+function [out, docTopic] = help(varargin)
+    if isdeployed
+        out = '';
+        docTopic = '';
+    else
+        [out, docTopic] = help(varargin);
+    end
+end


### PR DESCRIPTION
Fixes compiler warning
```
Warning: Excluded "C:/Program Files/MATLAB/R2022b/toolbox/matlab/helptools/help.m"; reason: The file or function has been excluded from packaging for the "MCR" target environment according
to the "Compiler" license.  Either remove the file or function from your code, or use the MATLAB function "isdeployed" to ensure the function is not invoked in the deployed component. 
> In compiler.internal.build.builder/Generic/build (line 83)
In compiler.build.standaloneApplication (line 119)
In compiler.internal.build.buildStandalonePRJ
In compiler.internal.build.legacyProject
In compiler.internal.package.legacyProject
In compiler.internal.launchui (line 60)
In deploytool (line 43) 
```

during compilation via
```
deploytool -package deployment\BiofilmQ.prj
```
on win10 with R2022b

Reason for the warning: The internal `help` version can not be shared in a compiled version. Prevent the usage by providing a custom `help` in `includes/matlab_funs` which returns empty strings when deployed otherwise the output of the internal functions.

Additionally I changed the hard coded paths in `BiofilmQ,prj` which prevents reproducible builds on other systems. In the future it might be better to entirely switch to `mcc` instead of using the `deploytool`.

I noticed that some `mexw64` files (in contrast to the `mexa64` and `mexmaci64` files) are not included by default but required for the build. The preferred solution would be to remove (and ignore via .gitignore) the Linux and Mac libraries as well and provide a script to manually build them prior to the package compilation.